### PR TITLE
Monitoring release vector

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -12,24 +12,29 @@ binaries:
   metal-stack:
     kernel:
       repository: https://github.com/metal-stack/kernel
-      url: https://github.com/metal-stack/kernel/releases/download/5.10.154-104/metal-kernel
-      version: 5.10.154-104
+      url: https://github.com/metal-stack/kernel/releases/download/5.10.162-105/metal-kernel
+      version: 5.10.162-105
     metal-hammer:
       repository: https://github.com/metal-stack/metal-hammer
       url: https://github.com/metal-stack/metal-hammer/releases/download/v0.11.1/metal-hammer-initrd.img.lz4
       version: v0.11.1
     metalctl:
       darwin:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-darwin-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-darwin-amd64
       linux:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-linux-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-linux-amd64
       repository: https://github.com/metal-stack/metalctl
-      version: v0.12.8
+      version: v0.12.9
       windows:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-windows-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-windows-amd64
 docker-images:
   metal-stack:
     control-plane:
+      monitoring:
+        rethinkdb-exporter:
+          name: ghcr.io/metal-stack/rethinkdb-exporter
+          repository: https://github.com/metal-stack/rethinkdb-exporter
+          version: v0.1.0
       masterdata-api:
         name: ghcr.io/metal-stack/masterdata-api
         repository: https://github.com/metal-stack/masterdata-api
@@ -42,15 +47,19 @@ docker-images:
         name: ghcr.io/metal-stack/metal-console
         repository: https://github.com/metal-stack/metal-console
         tag: v0.6.1
+      metal-metrics-exporter:
+        name: ghcr.io/metal-stack/metal-metrics-exporter
+        repository: https://github.com/metal-stack/metal-metrics-exporter
+        tag: v0.1.2
       metalctl:
         name: ghcr.io/metal-stack/metalctl
         repository: https://github.com/metal-stack/metalctl
-        tag: v0.12.8
+        tag: v0.12.9
     gardener:
       gardener-extension-provider-metal:
         name: ghcr.io/metal-stack/gardener-extension-provider-metal
         repository: https://github.com/metal-stack/gardener-extension-provider-metal
-        tag: v0.18.25
+        tag: v0.18.27
       machine-controller-manager:
         name: eu.gcr.io/gardener-project/gardener/machine-controller-manager
         repository: https://github.com/gardener/machine-controller-manager
@@ -154,12 +163,21 @@ docker-images:
         repository: https://github.com/docker-library/haproxy
         tag: 2.4-alpine
 helm-charts:
+  logging:
+    loki-stack:
+      repository: https://grafana.github.io/helm-charts
+      version: 2.8.9
   metal-stack:
     metal-control-plane:
       repository: https://helm.metal-stack.io
       version: 0.3.17
+  monitoring:
+    kube-prometheus-stack:
+      repository: https://prometheus-community.github.io/helm-charts
+      version:  42.1.0
+
 projects:
   metal-stack:
     mini-lab:
       repository: https://github.com/metal-stack/mini-lab
-      version: v0.3.1
+      version: v0.3.2

--- a/release.yaml
+++ b/release.yaml
@@ -12,29 +12,32 @@ binaries:
   metal-stack:
     kernel:
       repository: https://github.com/metal-stack/kernel
-      url: https://github.com/metal-stack/kernel/releases/download/5.10.162-105/metal-kernel
-      version: 5.10.162-105
+      url: https://github.com/metal-stack/kernel/releases/download/5.10.154-104/metal-kernel
+      version: 5.10.154-104
     metal-hammer:
       repository: https://github.com/metal-stack/metal-hammer
       url: https://github.com/metal-stack/metal-hammer/releases/download/v0.11.1/metal-hammer-initrd.img.lz4
       version: v0.11.1
     metalctl:
       darwin:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-darwin-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-darwin-amd64
       linux:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-linux-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-linux-amd64
       repository: https://github.com/metal-stack/metalctl
-      version: v0.12.9
+      version: v0.12.8
       windows:
-        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.9/metalctl-windows-amd64
+        url: https://github.com/metal-stack/metalctl/releases/download/v0.12.8/metalctl-windows-amd64
 docker-images:
   metal-stack:
     control-plane:
-      monitoring:
-        rethinkdb-exporter:
-          name: ghcr.io/metal-stack/rethinkdb-exporter
-          repository: https://github.com/metal-stack/rethinkdb-exporter
-          version: v0.1.0
+      event-exporter:
+        name: ghcr.io/metal-stack/event-exporter
+        repository: https://github.com/resmoio/kubernetes-event-exporter
+        version : v.1.1
+      rethinkdb-exporter:
+        name: ghcr.io/metal-stack/rethinkdb-exporter 
+        repository: https://github.com/metal-stack/rethinkdb-exporter
+        version: v0.1.0
       masterdata-api:
         name: ghcr.io/metal-stack/masterdata-api
         repository: https://github.com/metal-stack/masterdata-api
@@ -47,19 +50,15 @@ docker-images:
         name: ghcr.io/metal-stack/metal-console
         repository: https://github.com/metal-stack/metal-console
         tag: v0.6.1
-      metal-metrics-exporter:
-        name: ghcr.io/metal-stack/metal-metrics-exporter
-        repository: https://github.com/metal-stack/metal-metrics-exporter
-        tag: v0.1.2
       metalctl:
         name: ghcr.io/metal-stack/metalctl
         repository: https://github.com/metal-stack/metalctl
-        tag: v0.12.9
+        tag: v0.12.8
     gardener:
       gardener-extension-provider-metal:
         name: ghcr.io/metal-stack/gardener-extension-provider-metal
         repository: https://github.com/metal-stack/gardener-extension-provider-metal
-        tag: v0.18.27
+        tag: v0.18.25
       machine-controller-manager:
         name: eu.gcr.io/gardener-project/gardener/machine-controller-manager
         repository: https://github.com/gardener/machine-controller-manager
@@ -167,17 +166,16 @@ helm-charts:
     loki-stack:
       repository: https://grafana.github.io/helm-charts
       version: 2.8.9
-  metal-stack:
-    metal-control-plane:
-      repository: https://helm.metal-stack.io
-      version: 0.3.17
   monitoring:
     kube-prometheus-stack:
       repository: https://prometheus-community.github.io/helm-charts
       version:  42.1.0
-
+  metal-stack:
+    metal-control-plane:
+      repository: https://helm.metal-stack.io
+      version: 0.3.17
 projects:
   metal-stack:
     mini-lab:
       repository: https://github.com/metal-stack/mini-lab
-      version: v0.3.2
+      version: v0.3.1


### PR DESCRIPTION
Adding helm charts for prometheus-stack / loki-stack and exporters images {rethinkdb,event-exporter}.