### PR TITLE
Update observability stack

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -222,7 +222,10 @@ docker-images:
         tag: 2.4-alpine
       promtail:
         name: grafana/promtail
-        tag: 2.8.1
+        tag: 2.8.2
+      prometheus:
+        name: prom/prometheus
+        tag: v2.44.0
       ztp-nginx:
         name: nginx
         repository: https://github.com/nginxinc/docker-nginx
@@ -231,10 +234,10 @@ helm-charts:
   logging:
     loki:
       repository: https://grafana.github.io/helm-charts
-      version: 5.3.1
+      version: 5.8.9
     promtail:
       repository: https://grafana.github.io/helm-charts
-      version: 6.11.1
+      version: 6.11.5
   metal-stack:
     metal-control-plane:
       repository: https://helm.metal-stack.io
@@ -242,10 +245,10 @@ helm-charts:
   monitoring:
     kube-prometheus-stack:
       repository: https://prometheus-community.github.io/helm-charts
-      version: 45.24.0
+      version: 47.6.1
     thanos:
       repository: https://charts.bitnami.com/bitnami
-      version: 12.5.1
+      version: 12.8.3
   third-party:
     meilisearch:
       image_name: getmeili/meilisearch


### PR DESCRIPTION
grafana: 9.5.2 -> 10.0.1
loki: 2.8.1 -> 2.8.2
promtail: 2.8.1 -> 2.8.2
prometheus: 2.42.0 -> 2.44.0