### PR TITLE
Bump gardener-extension-shoot-cert-service to v1.44.2

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -213,7 +213,7 @@ docker-images:
         tag: v1.95.6
       shoot-cert-service:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/shoot-cert-service
-        tag: v1.42.0
+        tag: v1.44.2
       shoot-dns-service:
         name: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-dns-service
         tag: v1.48.0


### PR DESCRIPTION
## Description

Gardener 1.95 is used by 1.44.2, see https://github.com/gardener/gardener-extension-shoot-cert-service/blob/v1.44.2/go.mod#L8