### PR TITLE
Add cluster api provider metal stack

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -125,7 +125,7 @@ docker-images:
         repository: https://github.com/metal-stack/metal-dockerfiles
         tag: v0.7.7
     kubernetes:
-      cluster-api-provider-metal-stack:
+      cluster-api-provider-metal-stack-controller:
         name: ghcr.io/metal-stack/cluster-api-metal-stack-controller
         repository: https://github.com/metal-stack/cluster-api-provider-metal-stack
         tag: v0.6.0

--- a/release.yaml
+++ b/release.yaml
@@ -125,6 +125,10 @@ docker-images:
         repository: https://github.com/metal-stack/metal-dockerfiles
         tag: v0.7.7
     kubernetes:
+      cluster-api-provider-metal-stack:
+        name: ghcr.io/metal-stack/cluster-api-metal-stack-controller
+        repository: https://github.com/metal-stack/cluster-api-provider-metal-stack
+        tag: v0.6.0
       audit-forwarder:
         name: ghcr.io/metal-stack/audit-forwarder
         repository: https://github.com/metal-stack/audit-forwarder


### PR DESCRIPTION
## Description

Added the CAPMS below Kubernetes as it is simply installed in such a cluster.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
