### PR TITLE
Bump gardener-extension-networking-cilium to upstream `v1.42.3`.

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -277,11 +277,11 @@ docker-images:
         tag: v1.49.0
       networking-cilium:
         charts:
-          application: r.metal-stack.io/charts/admission-cilium-application
-          extension: r.metal-stack.io/charts/networking-cilium
-          runtime: r.metal-stack.io/charts/admission-cilium-runtime
-        name: r.metal-stack.io/gardener/gardener-extension-networking-cilium
-        tag: v1.41.3-ebpfmasqbackport
+          application: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-application
+          extension: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-cilium
+          runtime: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-runtime
+        name: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-cilium
+        tag: v1.42.3
       operator:
         charts:
           ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/operator


### PR DESCRIPTION
## Description

This is a bit pre-mature (as this is already revendored for g/g 1.124), but it resolves issues with K8s 1.33.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
