### PR TITLE
chore(gardener): v1.142.6

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -262,29 +262,29 @@ docker-images:
         tag: v1.17.0
       admission-controller:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/admission-controller
-        tag: v1.141.6
+        tag: v1.142.6
       api-server:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver
-        tag: v1.141.6
+        tag: v1.142.6
       controller-manager:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/controller-manager
-        tag: v1.141.6
+        tag: v1.142.6
       extension-admission-gcp:
         charts:
           application: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-gcp-application
           runtime: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-gcp-runtime
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/admission-gcp
-        tag: v1.50.0
+        tag: v1.51.0
       extension-provider-gcp:
         charts:
           extension: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/provider-gcp
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/provider-gcp
-        tag: v1.50.0
+        tag: v1.51.0
       gardenlet:
         charts:
           ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/gardenlet
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet
-        tag: v1.141.6
+        tag: v1.142.6
       metrics-exporter:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/metrics-exporter
         tag: 0.44.0
@@ -306,10 +306,10 @@ docker-images:
         charts:
           ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/operator
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/operator
-        tag: v1.141.6
+        tag: v1.142.6
       scheduler:
         name: europe-docker.pkg.dev/gardener-project/releases/gardener/scheduler
-        tag: v1.141.6
+        tag: v1.142.6
       shoot-cert-service:
         charts:
           extension: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-cert-service
@@ -321,7 +321,7 @@ docker-images:
           extension: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service
           runtime: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-runtime
         name: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-dns-service
-        tag: v1.82.0
+        tag: v1.83.0
       virtual-garden-apiserver:
         tag: v1.35.6
     partition:
@@ -395,5 +395,5 @@ repositories:
   third-party:
     gardener:
       gardener:
-        ref: v1.141.6
+        ref: v1.142.6
         url: https://github.com/gardener/gardener.git


### PR DESCRIPTION
## Description

Updates g/g to [1.142](https://github.com/gardener/gardener/releases/tag/v1.142.0)

## Release Notes

### Breaking Change

```BREAKING_CHANGE
- [OPERATOR] ⚠️ Gardener does no longer support Garden, Seed, or Shoot clusters with Kubernetes version `1.31`. Make sure to upgrade all existing clusters before upgrading to this Gardener version.
```
